### PR TITLE
Fixed wrong imports from settings.

### DIFF
--- a/django_sqs/__init__.py
+++ b/django_sqs/__init__.py
@@ -7,27 +7,31 @@ from registered_queue import RegisteredQueue, TimedOut, RestartLater
 
 
 # ensure settings are there
+if not getattr(settings, 'AWS_ACCESS_KEY_ID'):
+    raise ImproperlyConfigured('Missing setting "AWS_ACCESS_KEY_ID"')
 
-try:
-    from settings import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
-    if settings.DEBUG:
-        from settings import SQS_QUEUE_PREFIX
-except Exception, e:
-    raise ImproperlyConfigured("Misconfigured: %s" % e)
+if not getattr(settings, 'AWS_SECRET_ACCESS_KEY'):
+    raise ImproperlyConfigured('Missing setting "AWS_SECRET_ACCESS_KEY"')
+
+if settings.DEBUG and not getattr(settings, 'SQS_QUEUE_PREFIX'):
+    raise ImproperlyConfigured('Missing setting "SQS_QUEUE_PREFIX"')
 
 # Try to get regions, otherwise let to DefaultRegionName
-try:
-    from settings import AWS_REGION
-except Exception, e:
+# TODO this is bad! never set settings on the fly, better provide an
+# app_settings.py with default values
+if not getattr(settings, 'AWS_REGION'):
     settings.AWS_REGION = "us-east-1"
 
 
+# ============
 # registry
-
+# ============
 queues = {}
 
-# convenience
 
+# ============
+# convenience
+# ============
 def register(queue_name, fn=None, **kwargs):
     rv = RegisteredQueue(queue_name, fn, **kwargs)
     queues[queue_name] = rv


### PR DESCRIPTION
The way it is validated if certain settings are set in `__init__.py` is wrong.

https://docs.djangoproject.com/en/dev/topics/settings/#using-settings-in-python-code

You correctly import `from django.conf import settings` but this is an object and not a module, so subsequent import like `from settings import SETTING_NAME` cannot be done.

In the past this has only worked, because with the old django 1.3 project directory structure, the ROOT folder of the project contained an `__init__.py` and therefore was a Python module. The root folder also contained a `settings.py`, therefore you were able to import `from settings import XYZ`. Note that this import actually imports the `settings.py` in the project root and does not touch at all the import `from django.conf import settings` that has been done before.

With the new Django 1.4 project structure, the root no longer has an `__init__.py` and the settings.py lives inside a `myproject` module. Therefore suddenly it is no longer possible to do `from settings import ...` because there is no settings module anywhere in the python path.
